### PR TITLE
Add option to vectorize width=1 ports

### DIFF
--- a/abc_api.cc
+++ b/abc_api.cc
@@ -585,11 +585,13 @@ bool AbcApi::_endsession()
   }
   fprintf (vfp, ");\n");
 
+  int vectorize = (config_get_int("expropt.vectorize_all_ports") == 0) ? 0 : 1;
+
   for (listitem_t *li = list_first (iports); li; li = list_next (li)) {
     char *v = (char *) list_value (li);
     fprintf (vfp, "  input ");
     li = list_next (li);
-    if (list_ivalue (li) > 1) {
+    if (list_ivalue (li) > (1-vectorize)) {
       fprintf (vfp, "[%d:0] ", list_ivalue (li) - 1);
     }
     fprintf (vfp, "%s;\n", v);
@@ -599,7 +601,7 @@ bool AbcApi::_endsession()
     char *v = (char *) list_value (li);
     fprintf (vfp, "  output ");
     li = list_next (li);
-    if (list_ivalue (li) > 1) {
+    if (list_ivalue (li) > (1-vectorize)) {
       fprintf (vfp, "[%d:0] ", list_ivalue (li) - 1);
     }
     fprintf (vfp, "%s;\n", v);
@@ -617,7 +619,7 @@ bool AbcApi::_endsession()
     dim = list_ivalue (li);
       
     
-    if (dim < 2) {
+    if (dim < (2-vectorize)) {
       if (comma) { fprintf (vfp, ", "); }
       comma = 1;
       fprintf (vfp, "%s", v);
@@ -638,7 +640,7 @@ bool AbcApi::_endsession()
     li = list_next (li);
     dim = list_ivalue (li);
       
-    if (dim < 2) {
+    if (dim < (2-vectorize)) {
       if (comma) { fprintf (vfp, ", "); }
       comma = 1;
       fprintf (vfp, "%s", v);

--- a/expropt.cc
+++ b/expropt.cc
@@ -687,7 +687,7 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
   }
   fprintf(output_stream, " );\n");
 
-  int vectorize = config_get_int("expropt.vectorize_all_ports");
+  int vectorize = (config_get_int("expropt.vectorize_all_ports") == 0) ? 0 : 1;
 
   _varwidths.clear();
   // print input ports with bitwidth

--- a/expropt.cc
+++ b/expropt.cc
@@ -687,6 +687,8 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
   }
   fprintf(output_stream, " );\n");
 
+  int vectorize = config_get_int("expropt.vectorize_all_ports");
+
   _varwidths.clear();
   // print input ports with bitwidth
   fprintf(output_stream, "\n\t// print input ports with bitwidth\n");
@@ -708,7 +710,7 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
     // look up the bitwidth
     int width = ihash_lookup(inwidthmap, (long) list_value (li))->i;
     if ( width <=0 ) fatal_error("ExternalExprOpt::print_expr_verilog error: Expression operands have incompatible bit widths\n");
-    else if (width == 1) fprintf(output_stream, "\tinput %s ;\n", current.data());
+    else if (width == 1 && vectorize==0) fprintf(output_stream, "\tinput %s ;\n", current.data());
     else fprintf(output_stream, "\tinput [%i:0] %s ;\n", width-1, current.data());
     _varwidths[current] = width;
   }
@@ -736,7 +738,7 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
     // look up the bitwidth
     int width = ihash_lookup(outwidthmap, (long) list_value (li))->i;
     if ( width <=0 ) fatal_error("chpexpr2verilog::print_expr_set error: Expression operands have incompatible bit widths\n");
-    else if (width == 1) fprintf(output_stream, "\toutput %s ;\n", current.data());
+    else if (width == 1 && vectorize==0) fprintf(output_stream, "\toutput %s ;\n", current.data());
     else fprintf(output_stream, "\toutput [%i:0] %s ;\n", width-1, current.data());
     _varwidths[current] = width;
   }
@@ -766,7 +768,7 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
       // the bitwidth
       int width = ihash_lookup(outwidthmap, (long) list_value (li))->i;
       if ( width <=0 ) fatal_error("chpexpr2verilog::print_expr_set error: Expression operands have incompatible bit widths\n");
-      else if (width == 1) fprintf(output_stream, "\twire %s ;\n", current.data());
+      else if (width == 1 && vectorize==0) fprintf(output_stream, "\twire %s ;\n", current.data());
       else fprintf(output_stream, "\twire [%i:0] %s ;\n", width-1, current.data());
       list_append (all_names, current.data());
       _varwidths[current] = width;

--- a/expropt.conf
+++ b/expropt.conf
@@ -10,6 +10,10 @@ begin expropt
 # if syntesis files and logs are removed after being done (for debugging) - defaults to 1 (TRUE)
 # int clean_tmp_files 1
 
+# make size-1 input/output ports arrays, instead of single bool: default 0 
+# for eg. bool in -> bool in[1] 
+# int vectorize_all_ports 0
+
 # use abc constraints: default 0
 # int abc_use_constraints 0
 

--- a/expropt.h
+++ b/expropt.h
@@ -271,6 +271,7 @@ public:
                       { 
                           
                           config_set_default_int ("expropt.clean_tmp_files", 1);
+                          config_set_default_int ("expropt.vectorize_all_ports", 0);
                           config_set_default_int ("expropt.verbose", 1);
                           config_set_default_string ("expropt.act_cell_lib_qdi_namespace", "syn");
                           config_set_default_string ("expropt.act_cell_lib_qdi_wire_type", "sdtexprchan<1>");


### PR DESCRIPTION
- Added config int (default 0) that can optionally be set to make all ports arrays.
- If unset (set to 0), no behavior change.
- If set, even width=1 input/output ports are created as bool arrays, instead of just bools.
- Eg. bool in  ---(becomes)--> bool in[1]