### PR TITLE
Runtime logging

### DIFF
--- a/expropt.cc
+++ b/expropt.cc
@@ -25,6 +25,8 @@
 #include <string.h>
 #include "abc_api.h"
 #include <dlfcn.h>
+#include <chrono>
+using namespace std::chrono;
 
 #define VERILOG_FILE_PREFIX "exprop_"
 #define MAPPED_FILE_SUFFIX "_mapped"
@@ -411,9 +413,12 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
     syn.space  = _abc_api;
   }
   
+  auto start = high_resolution_clock::now();
   if (!(*_syn_run) (&syn)) {
     fatal_error ("Synthesis %s failed.", mapper);
   }
+  auto stop = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(stop - start);
 
   // read the resulting netlist and map it back to act, if the
   // wire_type is not bool use the async mode the specify a wire type
@@ -505,7 +510,8 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
 			    total_power,
 			    static_power,
 			    dynamic_power,
-			    area);
+			    area,
+          duration.count());
 
   // clean up temporary files
   if (_cleanup) {

--- a/expropt.cc
+++ b/expropt.cc
@@ -367,7 +367,7 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
       snprintf (buf, 1024, "%stmp", expr_set_name);
       module_name = buf;
     }
-    auto start2 = high_resolution_clock::now();
+    auto start_print_verilog = high_resolution_clock::now();
     print_expr_verilog(verilog_stream, module_name,
 		       in_expr_list,
 		       in_expr_map,
@@ -377,8 +377,8 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
 		       out_width_map,
 		       hidden_expr_list,
 		       hidden_expr_name_list);
-    auto stop2 = high_resolution_clock::now();
-    io_duration += duration_cast<microseconds>(stop2 - start2);
+    auto stop_print_verilog = high_resolution_clock::now();
+    io_duration += duration_cast<microseconds>(stop_print_verilog - start_print_verilog);
   }
 
   // close Verilog file
@@ -418,12 +418,12 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
     syn.space  = _abc_api;
   }
   
-  auto start = high_resolution_clock::now();
+  auto start_mapper = high_resolution_clock::now();
   if (!(*_syn_run) (&syn)) {
     fatal_error ("Synthesis %s failed.", mapper);
   }
-  auto stop = high_resolution_clock::now();
-  auto duration = duration_cast<microseconds>(stop - start);
+  auto stop_mapper = high_resolution_clock::now();
+  auto duration = duration_cast<microseconds>(stop_mapper - start_mapper);
 
   // read the resulting netlist and map it back to act, if the
   // wire_type is not bool use the async mode the specify a wire type
@@ -464,10 +464,10 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
       fflush(stdout);
     }
     
-    auto start3 = high_resolution_clock::now();
+    auto start_v2act = high_resolution_clock::now();
     exec_failure = system(cmd);
-    auto stop3 = high_resolution_clock::now();
-    io_duration += duration_cast<microseconds>(stop3 - start3);
+    auto stop_v2act = high_resolution_clock::now();
+    io_duration += duration_cast<microseconds>(stop_v2act - start_v2act);
     if (exec_failure != 0) {
       fatal_error("external program call \"%s\" failed.", cmd);
     }

--- a/expropt.h
+++ b/expropt.h
@@ -97,6 +97,7 @@ private:
   metric_triplet dynamic_power; //<  power value (W)
   metric_triplet total_power;	//<  total power (W)
   long long mapper_runtime; //<  logic synthesis tool runtime (us)
+  long long interface_runtime; //< interface tools (verilog_printing + v2act) runtime (us)
 
   /**
    * the theoretical area of all gates combined, with 100% utiliasation.
@@ -112,6 +113,7 @@ public:
   metric_triplet getPower() { return total_power; }
   double getArea() { return area; }
   long long getRuntime() { return mapper_runtime; }
+  long long getIORuntime() { return interface_runtime; }
 
   /**
    * Construct a new Expr Block Info object, values can not be changed after creation.
@@ -123,13 +125,15 @@ public:
 		const metric_triplet e_static_power,
 		const metric_triplet e_dynamic_power,
 		const double e_area,
-    const long long e_runtime) :
+    const long long e_runtime,
+    const long long e_io_runtime) :
     delay{e_delay},
     total_power{e_power},
     static_power{e_static_power},
     dynamic_power{e_dynamic_power},
     area{e_area},
-    mapper_runtime{e_runtime}
+    mapper_runtime{e_runtime},
+    interface_runtime{e_io_runtime}
   { }
                     
   /**

--- a/expropt.h
+++ b/expropt.h
@@ -96,6 +96,7 @@ private:
   metric_triplet static_power;	//< power value (W)
   metric_triplet dynamic_power; //<  power value (W)
   metric_triplet total_power;	//<  total power (W)
+  long long mapper_runtime; //<  logic synthesis tool runtime (us)
 
   /**
    * the theoretical area of all gates combined, with 100% utiliasation.
@@ -110,6 +111,7 @@ public:
   metric_triplet getDynamicPower() { return dynamic_power; }
   metric_triplet getPower() { return total_power; }
   double getArea() { return area; }
+  long long getRuntime() { return mapper_runtime; }
 
   /**
    * Construct a new Expr Block Info object, values can not be changed after creation.
@@ -120,12 +122,14 @@ public:
 		const metric_triplet e_power,
 		const metric_triplet e_static_power,
 		const metric_triplet e_dynamic_power,
-		const double e_area) :
+		const double e_area,
+    const long long e_runtime) :
     delay{e_delay},
     total_power{e_power},
     static_power{e_static_power},
     dynamic_power{e_dynamic_power},
-    area{e_area}
+    area{e_area},
+    mapper_runtime{e_runtime}
   { }
                     
   /**


### PR DESCRIPTION
Add support for logging runtime of mapper and interface (printing verilog + running v2act).
ExprBlockInfo now has two more fields, which contain this information. 