### PR TITLE
Verilog file caching

### DIFF
--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -160,7 +160,8 @@ ExprCache::ExprCache(const char *datapath_synthesis_tool,
     read_cache();
 }
 
-std::string ExprCache::_gen_unique_id (Expr *e, list_t *in_expr_list, iHashtable *width_map)
+std::string ExprCache::_gen_unique_id (Expr *e, list_t *in_expr_list, 
+                        iHashtable *width_map, int outwidth)
 {
     list_t *vars = list_new();
     act_expr_collect_ids (vars, e);
@@ -174,6 +175,8 @@ std::string ExprCache::_gen_unique_id (Expr *e, list_t *in_expr_list, iHashtable
         uniq_id.append("_");
         uniq_id.append(std::to_string(width));
     }
+    uniq_id.append("_");
+    uniq_id.append(std::to_string(outwidth));
     return uniq_id;
 }
 
@@ -184,7 +187,7 @@ ExprBlockInfo *ExprCache::synth_expr (int expr_set_number,
                                       iHashtable *in_expr_map,
                                       iHashtable *in_width_map)
 {
-    std::string uniq_id = _gen_unique_id(expr, in_expr_list, in_width_map);
+    std::string uniq_id = _gen_unique_id(expr, in_expr_list, in_width_map, targetwidth);
 
     // already have it
     if (path_map.contains(uniq_id)) {

--- a/expr_cache.h
+++ b/expr_cache.h
@@ -68,7 +68,7 @@ private:
     int lock_file (std::string);
     void unlock_file (int);
 
-    std::string _gen_unique_id (Expr *, list_t *, iHashtable *);
+    std::string _gen_unique_id (Expr *, list_t *, iHashtable *, int);
 
     /*
         define a next() function for the

--- a/expr_cache.h
+++ b/expr_cache.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <act/expropt.h>
+// #include "expropt.h"
 
 /*
     Path of an expression file within the cache.
@@ -30,7 +31,6 @@
 typedef int expr_path;
 
 static const std::string _tmp_expr_file = "tmp_expr.act";
-static const std::string _cache_dummy_ns = "_cache_ns_";
 
 class ExprCache : public ExternalExprOpt {
 public:
@@ -59,7 +59,11 @@ private:
     void read_cache ();
     void read_cache_index_line (std::string);
     void write_cache_index_line (std::string);
-    void rename_and_pipe (std::ifstream &, std::ofstream &, const std::string, const std::string);
+    void rename_and_pipe (std::ifstream &, std::ofstream &, 
+                            const std::vector<std::string>, 
+                            const std::vector<std::string>);
+
+    void v2act_and_pipe (std::ifstream &src, std::ofstream &dst);
 
     int lock_file (std::string);
     void unlock_file (int);
@@ -73,6 +77,9 @@ private:
     expr_path gen_expr_path () {
         return cache_counter++;
     }
+
+    std::vector<std::string> s_orig;
+    std::vector<std::string> s_cache;
 
     std::string path;
     std::string index_file;

--- a/expr_info.h
+++ b/expr_info.h
@@ -104,6 +104,7 @@ private:
     metric_triplet total_power;	//<  total power (W)
     long long mapper_runtime; //<  logic synthesis tool runtime (us)
     long long interface_runtime; //< interface tools (verilog_printing + v2act) runtime (us)
+    std::string mapped_file; //< mapped verilog file
 
     /*
     * the theoretical area of all gates combined, with 100% utiliasation.
@@ -120,6 +121,7 @@ public:
     double getArea() { return area; }
     long long getRuntime() { return mapper_runtime; }
     long long getIORuntime() { return interface_runtime; }
+    std::string getMappedFile() { return mapped_file; }
 
     /**
      * Construct a new Expr Block Info object, 
@@ -132,14 +134,16 @@ public:
             const metric_triplet e_dynamic_power,
             const double e_area,
         const long long e_runtime,
-        const long long e_io_runtime) :
+        const long long e_io_runtime,
+        std::string e_mapped_file) :
         delay{e_delay},
         total_power{e_power},
         static_power{e_static_power},
         dynamic_power{e_dynamic_power},
         area{e_area},
         mapper_runtime{e_runtime},
-        interface_runtime{e_io_runtime}
+        interface_runtime{e_io_runtime},
+        mapped_file{e_mapped_file}
     { }
                         
     /**

--- a/expropt.conf
+++ b/expropt.conf
@@ -99,16 +99,20 @@ begin synth
 
         begin abc
             # use abc constraints: default 0
-            # int use_constraints 0
+            int use_constraints 1
         end
 
         # the captable for the tech (optional) - white space to seperate files inside string
         # string captable
+
         # the lef file for the tech + lib  (optional) - white space to seperate files inside string
         # if the techlef is seperate it has to be the first file!
         # string lef 
 
         begin genus
+
+            # search path for files
+            # string searchpath
 
             # the sdf for genus to load (needed for genus corner analysis)
             # string timing_constraint_sdf

--- a/expropt.h
+++ b/expropt.h
@@ -25,7 +25,8 @@
 #include <regex>
 #include <fstream>
 #include <unordered_map>
-#include <act/expr_info.h>
+// #include <act/expr_info.h>
+#include "expr_info.h"
 
 /**
  * ExternalExprOpt is an interface that wrapps the syntesis, optimisation and mapping to cells of a set of act expr.
@@ -177,7 +178,8 @@ public:
 				   Expr *e,
 				   list_t *in_expr_list,
 				   iHashtable *in_expr_map,
-				   iHashtable *in_width_map);
+				   iHashtable *in_width_map,
+           bool run_backend = true);
 
   /**
    * Simple C-STRING MODE - set of expr - recomended mode - outputs are
@@ -225,7 +227,8 @@ public:
 				   list_t *out_expr_list,
 				   iHashtable *out_expr_map,
 				   iHashtable *out_width_map,
-				   list_t *hidden_expr_list = NULL);
+				   list_t *hidden_expr_list = NULL,
+           bool run_backend = true);
 
   
   /**
@@ -277,7 +280,8 @@ public:
 				   list_t *out_expr_name_list,
 				   iHashtable *out_width_map,
 				   list_t *hidden_expr_list = NULL,
-				   list_t *hidden_expr_name_list = NULL);
+				   list_t *hidden_expr_name_list = NULL,
+           bool run_backend = true);
 
 
 protected:
@@ -287,6 +291,12 @@ protected:
 				//< to override any of the defaults.
 
   bool _cleanup;
+  void cleanup_tmp_files();
+
+  act_syn_info __syn;
+
+  void run_v2act(std::string, bool);
+  ExprBlockInfo *backend(std::string, std::chrono::microseconds, std::chrono::microseconds);
   
   /**
    * print the verilog module, internal takes the inputs and outputs as lists of expressions (plus the properites name and width as maps). 


### PR DESCRIPTION
Update caching to store mapped verilog files.
Runs v2act with appropriate options on cache call and redirects output.
Had to perform some surgery on the expropt functions to enable this..
Append output width to unique identifier.