### PR TITLE
Fixes to Caching

### DIFF
--- a/expr_cache.h
+++ b/expr_cache.h
@@ -47,7 +47,7 @@ public:
         run_external_opt for the expropt object. 
         Arguments are exactly the same.
     */
-    ExprBlockInfo *synth_expr (int, int, Expr *, list_t *, iHashtable *, iHashtable *);
+    ExprBlockInfo *synth_expr (int, Expr *, list_t *, iHashtable *, iHashtable *);
 
     /*
         Get path to cache that is being used.
@@ -78,9 +78,6 @@ private:
         return cache_counter++;
     }
 
-    std::vector<std::string> s_orig;
-    std::vector<std::string> s_cache;
-
     std::string path;
     std::string index_file;
 
@@ -99,5 +96,9 @@ private:
     std::unordered_map<std::string, expr_path> path_map;
     // Path-to-info
     std::unordered_map<expr_path, ExprBlockInfo> info_map;
+
+    // Keep track of which exprs have already been copied over
+    // To avoid double-defining the same expr blk
+    std::unordered_set<std::string> runtime_accessed_set;
 
 };

--- a/expr_info.h
+++ b/expr_info.h
@@ -105,6 +105,7 @@ private:
     long long mapper_runtime; //<  logic synthesis tool runtime (us)
     long long interface_runtime; //< interface tools (verilog_printing + v2act) runtime (us)
     std::string mapped_file; //< mapped verilog file
+    std::string unique_id; //< unique id for the generated expression (cache only)
 
     /*
     * the theoretical area of all gates combined, with 100% utiliasation.
@@ -122,6 +123,8 @@ public:
     long long getRuntime() { return mapper_runtime; }
     long long getIORuntime() { return interface_runtime; }
     std::string getMappedFile() { return mapped_file; }
+    std::string getID() { return unique_id; }
+    void setID(std::string s) { unique_id = s; }
 
     /**
      * Construct a new Expr Block Info object, 
@@ -135,7 +138,8 @@ public:
             const double e_area,
         const long long e_runtime,
         const long long e_io_runtime,
-        std::string e_mapped_file) :
+        std::string e_mapped_file,
+        std::string e_unique_id) :
         delay{e_delay},
         total_power{e_power},
         static_power{e_static_power},
@@ -143,7 +147,8 @@ public:
         area{e_area},
         mapper_runtime{e_runtime},
         interface_runtime{e_io_runtime},
-        mapped_file{e_mapped_file}
+        mapped_file{e_mapped_file},
+        unique_id{e_unique_id}
     { }
                         
     /**

--- a/expropt.h
+++ b/expropt.h
@@ -179,7 +179,18 @@ public:
 				   list_t *in_expr_list,
 				   iHashtable *in_expr_map,
 				   iHashtable *in_width_map,
-           bool run_backend = true);
+           bool __cleanup = true);
+
+  /* 
+   * Same as above but with string name
+   */
+  ExprBlockInfo* run_external_opt (std::string expr_name,
+				   int targetwidth,
+				   Expr *e,
+				   list_t *in_expr_list,
+				   iHashtable *in_expr_map,
+				   iHashtable *in_width_map,
+           bool __cleanup = true);
 
   /**
    * Simple C-STRING MODE - set of expr - recomended mode - outputs are
@@ -228,7 +239,7 @@ public:
 				   iHashtable *out_expr_map,
 				   iHashtable *out_width_map,
 				   list_t *hidden_expr_list = NULL,
-           bool run_backend = true);
+           bool __cleanup = true);
 
   
   /**
@@ -281,7 +292,7 @@ public:
 				   iHashtable *out_width_map,
 				   list_t *hidden_expr_list = NULL,
 				   list_t *hidden_expr_name_list = NULL,
-           bool run_backend = true);
+           bool __cleanup = true);
 
 
 protected:
@@ -343,7 +354,7 @@ protected:
     /**
      * the output file name where all act results are appended too.
      */
-    const std::string expr_output_file;
+    std::string expr_output_file;
 
     /**
      * the act cell lib read from the config file


### PR DESCRIPTION
Problem: cached expr-block names are fixed but were not unique, so if the same expr-block is used several times in a synthesis run, there is a duplicate definition problem. Also, the names could conflict if some expr-blocks are copied from cache and some are freshly generated in the same output expr_file. 

Fix: Cached processes now have the uniq_id as part of the name. The cache also keeps track of all the processes that were copied over to the output expr file, and so each is only copied once. 