### PR TITLE
increase char buffer sizes

### DIFF
--- a/abc.cc
+++ b/abc.cc
@@ -80,7 +80,7 @@ bool abc_run (act_syn_info *s)
 
 static double parse_abc_info (const char *file, double *area)
 {
-  char buf[10240];
+  char buf[char_buf_sz];
   FILE *fp;
   double ret;
 
@@ -96,7 +96,7 @@ static double parse_abc_info (const char *file, double *area)
     *area = 0;
   }
 
-  while (fgets (buf, 10240, fp)) {
+  while (fgets (buf, char_buf_sz, fp)) {
     char *tmp = strstr (buf, "Delay =");
     if (tmp) {
       if (sscanf (tmp, "Delay = %lf ps", &ret) == 1) {
@@ -107,7 +107,7 @@ static double parse_abc_info (const char *file, double *area)
     else {
       tmp = strstr (buf, "Fanin =");
       if (tmp) {
-	char cellname[1000];
+	char cellname[char_buf_sz];
 	int inst;
 	double tot_area;
 	if (sscanf (buf, "%s Fanin = %*d Instance = %d Area = %lg",
@@ -153,14 +153,14 @@ void abc_cleanup (act_syn_info *s)
 {
   char *sdc_file;
   int len;
-  char cmd[4096];
+  char cmd[char_buf_sz];
 
   len = strlen (s->v_in);
   MALLOC (sdc_file, char, len+3);
   snprintf (sdc_file, len + 3, "%s", s->v_in);
   snprintf (sdc_file + len - 2, 5, ".sdc");
   
-  snprintf(cmd, 4096, "rm %s && rm %s && rm %s && rm %s.* ",
+  snprintf(cmd, char_buf_sz, "rm %s && rm %s && rm %s && rm %s.* ",
 	   s->v_out, s->v_in, sdc_file, s->v_out);
 
   if (config_get_int("synth.expropt.verbose") == 2) {

--- a/abc_api.cc
+++ b/abc_api.cc
@@ -98,7 +98,7 @@ void AbcApi::_mainloop()
   int sz, pos;
   int cmd_end;
 
-  buf_max = 1024;
+  buf_max = char_buf_sz_abc;
   MALLOC (buf, char, buf_max);
 
 #define GET_MORE					\
@@ -118,7 +118,7 @@ void AbcApi::_mainloop()
       GET_MORE;
     }
 
-    if (sz < 1024) {
+    if (sz < char_buf_sz_abc) {
       buf[sz] = '\0';
     }
     
@@ -249,7 +249,7 @@ bool AbcApi::_run_abc (char *cmd)
 
 bool AbcApi::_startsession(char *args)
 {
-  char buf[1024];
+  char buf[char_buf_sz_abc];
   Assert (_parent == false, "What?");
 
 
@@ -282,7 +282,7 @@ bool AbcApi::_startsession(char *args)
 
   _vout = Strdup (name);
       
-  snprintf (buf, 1024, "%s.log", _vout);
+  snprintf (buf, char_buf_sz_abc, "%s.log", _vout);
   _logfd = open (buf, O_CREAT|O_TRUNC|O_RDWR, S_IRUSR|S_IWUSR);
 
   if (_logfd < 0) {
@@ -298,11 +298,11 @@ bool AbcApi::_startsession(char *args)
   _pAbc = Abc_FrameGetGlobalFrame ();
   
   // read Verilog, blast it, and read in the liberty file
-  snprintf (buf, 1024, "%%read %s; %%blast; &put", _vin);
+  snprintf (buf, char_buf_sz_abc, "%%read %s; %%blast; &put", _vin);
   if (!_run_abc (buf)) return false;
 
   char *lib = config_get_string("synth.liberty.typical");
-  snprintf (buf, 1024, "read_lib -v %s", lib);
+  snprintf (buf, char_buf_sz_abc, "read_lib -v %s", lib);
   if (!_run_abc (buf)) return false;
 
   int constr = 0;
@@ -320,7 +320,7 @@ bool AbcApi::_startsession(char *args)
       name[len-1] = '\0';
       name[len-2] = '\0';
     }
-    snprintf (buf, 1024, "read_constr %s.sdc", name);
+    snprintf (buf, char_buf_sz_abc, "read_constr %s.sdc", name);
     FREE (name);
     if (!_run_abc (buf)) return false;
   }
@@ -576,7 +576,7 @@ static bool my_fgets (char **buf, int *buf_max, FILE *fp)
 
 bool AbcApi::_endsession()
 {
-  int buf_max = 10240;
+  int buf_max = char_buf_sz_abc;
   char *buf;
 
   if (!_pAbc) {
@@ -585,20 +585,20 @@ bool AbcApi::_endsession()
 
   MALLOC (buf, char, buf_max);
 
-  snprintf (buf, 1024, "write_verilog %s", _vout);
+  snprintf (buf, char_buf_sz_abc, "write_verilog %s", _vout);
   _run_abc (buf);
   fflush (stdout);
   fflush (stderr);
   write (_logfd, "\n", 1);
   
-  snprintf (buf, 1024, "print_io; print_gates");
+  snprintf (buf, char_buf_sz_abc, "print_io; print_gates");
   _run_abc (buf);
   fflush (stdout);
   fflush (stderr);
 
   FILE *fp;
   FILE *vfp;
-  snprintf (buf, 1024, "%s.log", _vout);
+  snprintf (buf, char_buf_sz_abc, "%s.log", _vout);
   if (!(fp = fopen (buf, "r"))) {
     FREE (buf);
     return false;
@@ -639,7 +639,7 @@ bool AbcApi::_endsession()
   }
   fclose (fp);
 
-  snprintf (buf, 1024, "%s", _vout);
+  snprintf (buf, char_buf_sz_abc, "%s", _vout);
   vfp = fopen (buf, "a");
   fprintf (vfp, "module %s (", _name);
 

--- a/abc_api.h
+++ b/abc_api.h
@@ -22,6 +22,8 @@
 #ifndef __EXPROPT_ABC_API_H__
 #define __EXPROPT_ABC_API_H__
 
+static const int char_buf_sz_abc = 1024*32;
+
 /*
  * Minimal API to abc
  */

--- a/expropt.cc
+++ b/expropt.cc
@@ -45,11 +45,11 @@ ExternalExprOpt::~ExternalExprOpt()
 bool ExternalExprOpt::engineExists (const char *s)
 {
   // if a mapper string has been specified, find the library!
-  char buf[10240];
+  char buf[char_buf_sz];
   
   if (!getenv ("ACT_HOME")) return false;
   
-  snprintf (buf, 10240, "%s/lib/act_extsyn_%s.so", getenv ("ACT_HOME"), s);
+  snprintf (buf, char_buf_sz, "%s/lib/act_extsyn_%s.so", getenv ("ACT_HOME"), s);
 
   FILE *fp = fopen (buf, "r");
   if (!fp) {
@@ -108,8 +108,8 @@ void ExternalExprOpt::_init_defaults ()
   }
 
   // if a mapper string has been specified, find the library!
-  char buf[10240];
-  snprintf (buf, 10240, "%s/lib/act_extsyn_%s.so",
+  char buf[char_buf_sz];
+  snprintf (buf, char_buf_sz, "%s/lib/act_extsyn_%s.so",
 	    getenv ("ACT_HOME"),
 	    mapper);
   _syn_dlib = dlopen (buf, RTLD_LAZY);
@@ -117,17 +117,17 @@ void ExternalExprOpt::_init_defaults ()
     fatal_error ("could not open `%s' external logic synthesis library!", buf);
   }
 
-  snprintf (buf, 10240, "%s_run", mapper);
+  snprintf (buf, char_buf_sz, "%s_run", mapper);
   *((void **)&_syn_run)= dlsym (_syn_dlib, buf);
   if (!_syn_run) {
     fatal_error ("Expression synthesis library `%s': missing %s!", mapper, buf);
   }
-  snprintf (buf, 10240, "%s_get_metric", mapper);
+  snprintf (buf, char_buf_sz, "%s_get_metric", mapper);
   *((void **)&_syn_get_metric) = dlsym (_syn_dlib, buf);
   if (!_syn_get_metric) {
     fatal_error ("Expression synthesis library `%s': missing %s", mapper, buf);
   }
-  snprintf (buf, 10240, "%s_cleanup", mapper);
+  snprintf (buf, char_buf_sz, "%s_cleanup", mapper);
   *((void **)&_syn_cleanup) = dlsym (_syn_dlib, buf);
   if (!_syn_cleanup) {
     fatal_error ("Expression synthesis library `%s': missing %s", mapper, buf);
@@ -166,17 +166,17 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (std::string expr_name,
     // change from int to C string
     ihash_bucket_t *b_map,*b_new;
     b_map = ihash_lookup(in_expr_map, (long) e);
-    char *charbuf = (char *) malloc( sizeof(char) * ( 1024 + 1 ) );
-    snprintf(charbuf, 1024, "%s%u",expr_prefix.data(),b_map->i);
+    char *charbuf = (char *) malloc( sizeof(char) * ( char_buf_sz + 1 ) );
+    snprintf(charbuf, char_buf_sz, "%s%u",expr_prefix.data(),b_map->i);
     b_new = ihash_add(inexprmap, (long) e);
     b_new->v = charbuf;
   }
 
   ihash_bucket_t *b_map;
-  char *charbuf = (char *) malloc( sizeof(char) * ( 1024 + 1 ) );
+  char *charbuf = (char *) malloc( sizeof(char) * ( char_buf_sz + 1 ) );
 
   // the output should be called "out"
-  snprintf(charbuf,1024, "out");
+  snprintf(charbuf,char_buf_sz, "out");
   b_map = ihash_add(outexprmap,(long) expr);
   b_map->v = charbuf;
 
@@ -189,8 +189,8 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (std::string expr_name,
   b_width->i = targetwidth;
 
   // generate module name 
-  char expr_set_name[1024];
-  snprintf(expr_set_name, 1024, "%s%s",module_prefix.data(), expr_name.c_str());
+  char expr_set_name[char_buf_sz];
+  snprintf(expr_set_name, char_buf_sz, "%s%s",module_prefix.data(), expr_name.c_str());
   
   // and send off
   info = run_external_opt(expr_set_name,
@@ -256,17 +256,17 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (int expr_set_number,
     // change from int to C string
     ihash_bucket_t *b_map,*b_new;
     b_map = ihash_lookup(in_expr_map, (long) e);
-    char *charbuf = (char *) malloc( sizeof(char) * ( 1024 + 1 ) );
-    snprintf(charbuf, 1024, "%s%u",expr_prefix.data(),b_map->i);
+    char *charbuf = (char *) malloc( sizeof(char) * ( char_buf_sz + 1 ) );
+    snprintf(charbuf, char_buf_sz, "%s%u",expr_prefix.data(),b_map->i);
     b_new = ihash_add(inexprmap, (long) e);
     b_new->v = charbuf;
   }
 
   ihash_bucket_t *b_map;
-  char *charbuf = (char *) malloc( sizeof(char) * ( 1024 + 1 ) );
+  char *charbuf = (char *) malloc( sizeof(char) * ( char_buf_sz + 1 ) );
 
   // the output should be called "out"
-  snprintf(charbuf,1024, "out");
+  snprintf(charbuf,char_buf_sz, "out");
   b_map = ihash_add(outexprmap,(long) expr);
   b_map->v = charbuf;
 
@@ -279,8 +279,8 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (int expr_set_number,
   b_width->i = targetwidth;
 
   // generate module name 
-  char expr_set_name[1024];
-  snprintf(expr_set_name, 1024, "%s%u",module_prefix.data(), expr_set_number);
+  char expr_set_name[char_buf_sz];
+  snprintf(expr_set_name, char_buf_sz, "%s%u",module_prefix.data(), expr_set_number);
   
   // and send off
   info = run_external_opt(expr_set_name,
@@ -445,14 +445,14 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (const char* expr_set_name,
 
   // generate verilog module
   {
-    char buf[1024];
+    char buf[char_buf_sz];
     const char *module_name = expr_set_name;
     
     if (strcmp (mapper, "abc") == 0) {
       /* abc is going to mess up the port names, so we need to fix
 	 that; we do this by changing the Verilog module name, and then
 	 creating a dummy passthru instance in the abc API (abc_api.cc) */
-      snprintf (buf, 1024, "%stmp", expr_set_name);
+      snprintf (buf, char_buf_sz, "%stmp", expr_set_name);
       module_name = buf;
     }
     auto start_print_verilog = high_resolution_clock::now();
@@ -588,14 +588,14 @@ ExprBlockInfo *ExternalExprOpt::backend(std::string _mapped_file,
 
 void ExternalExprOpt::run_v2act(std::string _mapped_file, bool tie_cells)
 {
-  char cmd[4096] = "";
+  char cmd[char_buf_sz] = "";
   // read the resulting netlist and map it back to act, if the
   // wire_type is not bool use the async mode the specify a wire type
   // as a channel.  skip if run was just for extraction of properties
   // => output filename empty
   if (wire_encoding == qdi) {
     // QDI, so we don't add tie cells
-    snprintf(cmd, 4096, "v2act -a -C \"%s\" -l %s -n %s %s >> %s",
+    snprintf(cmd, char_buf_sz, "v2act -a -C \"%s\" -l %s -n %s %s >> %s",
         expr_channel_type.data(),
         cell_act_file.data(),
         cell_namespace.data(),
@@ -604,14 +604,14 @@ void ExternalExprOpt::run_v2act(std::string _mapped_file, bool tie_cells)
   }
   else {
     if (!(tie_cells)) {
-      snprintf(cmd, 4096, "v2act -t -l %s -n %s %s >> %s",
+      snprintf(cmd, char_buf_sz, "v2act -t -l %s -n %s %s >> %s",
         cell_act_file.data(),
         cell_namespace.data(),
         _mapped_file.data(),
         expr_output_file.data());
     }
     else {
-      snprintf(cmd, 4096, "v2act -l %s -n %s %s >> %s",
+      snprintf(cmd, char_buf_sz, "v2act -l %s -n %s %s >> %s",
         cell_act_file.data(),
         cell_namespace.data(),
         _mapped_file.data(),

--- a/expropt.h
+++ b/expropt.h
@@ -28,6 +28,8 @@
 // #include <act/expr_info.h>
 #include "expr_info.h"
 
+static const int char_buf_sz = 1024*32;
+
 /**
  * ExternalExprOpt is an interface that wrapps the syntesis, optimisation and mapping to cells of a set of act expr.
  * it will also give you metadata back if the software supports it. 

--- a/verilog.cc
+++ b/verilog.cc
@@ -248,8 +248,8 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
       if (skip) continue;
      // also print the hidden assigns
       int idx = print_expression(output_stream, e, inexprmap);
-      char buf[100];
-      _gen_dummy_id (buf, 100, idx);
+      char buf[char_buf_sz];
+      _gen_dummy_id (buf, char_buf_sz, idx);
       fprintf(output_stream,"\tassign %s = %s;\n", current.data(), buf);
     }
   }
@@ -260,10 +260,10 @@ void ExternalExprOpt::print_expr_verilog (FILE *output_stream,
   for (li = list_first (out_list); li; li = list_next (li))
   {
     Expr *e = (Expr*) list_value (li);
-    char buf[100];
+    char buf[char_buf_sz];
     std::string current = (char *) list_value (li_name);
     int idx = print_expression(output_stream, e, inexprmap);
-    _gen_dummy_id (buf, 100, idx);
+    _gen_dummy_id (buf, char_buf_sz, idx);
     fprintf(output_stream,"\tassign %s = %s;\n", current.data(), buf);
     li_name = list_next(li_name);
   }
@@ -295,7 +295,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
   int lw, rw;
   int lidx, ridx;
   int res, resw;
-  char buf[100];
+  char buf[char_buf_sz];
   Expr *orig_e = e;
 
   phash_bucket_t *b;
@@ -314,7 +314,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
 #define DUMP_DECL_ASSIGN						\
   do {									\
     res = _gen_fresh_idx ();						\
-    _gen_dummy_id (buf, 100, res);					\
+    _gen_dummy_id (buf, char_buf_sz, res);					\
     if (resw == 1) {							\
       fprintf (output_stream, "\twire %s;\n", buf);			\
     }									\
@@ -341,7 +341,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     DUMP_DECL_ASSIGN;
 
     /* rhs */
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf (output_stream, "%s ? 1'b1 : 1'b0", buf);
     break;
 
@@ -356,7 +356,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     }
     DUMP_DECL_ASSIGN;
 
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf (output_stream, "%s", buf); 
     
     break;
@@ -368,11 +368,11 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     resw = act_expr_bitwidth (e->type, lw, rw);
 
     DUMP_DECL_ASSIGN;
-    _gen_dummy_id (buf, 100, tmp);
+    _gen_dummy_id (buf, char_buf_sz, tmp);
     fprintf (output_stream, " %s ? ", buf);
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf (output_stream, " %s : ", buf);
-    _gen_dummy_id (buf, 100, ridx);
+    _gen_dummy_id (buf, char_buf_sz, ridx);
     fprintf (output_stream, " %s", buf);
     break;
     
@@ -396,7 +396,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     resw = act_expr_bitwidth (e->type, lw, rw);
     DUMP_DECL_ASSIGN;
 
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf(output_stream, "%s ", buf);
     if (e->type == E_AND) {
       fprintf (output_stream, "&");
@@ -440,7 +440,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     else if (e->type == E_NE) {
       fprintf (output_stream, "!=");
     }
-    _gen_dummy_id (buf, 100, ridx);
+    _gen_dummy_id (buf, char_buf_sz, ridx);
     fprintf(output_stream, " %s", buf);
     break;
 
@@ -458,7 +458,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     else if (e->type == E_UMINUS) {
       fprintf(output_stream, "-");
     }
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf (output_stream, "%s", buf);
     break;
 
@@ -473,7 +473,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
 
     /* pad left */
     DUMP_DECL_ASSIGN;
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     if (lw < resw) {
       fprintf (output_stream, "{%d'b", resw-lw);
       for (int i=0; i < resw-lw; i++) {
@@ -490,7 +490,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     lidx = res;
 
     DUMP_DECL_ASSIGN;
-    _gen_dummy_id (buf, 100, ridx);
+    _gen_dummy_id (buf, char_buf_sz, ridx);
     if (rw < resw) {
       fprintf (output_stream, "{%d'b", resw-rw);
       for (int i=0; i < resw-rw; i++) {
@@ -507,7 +507,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     ridx = res;
     
     DUMP_DECL_ASSIGN;
-    _gen_dummy_id (buf, 100, lidx);
+    _gen_dummy_id (buf, char_buf_sz, lidx);
     fprintf(output_stream, "%s ", buf);
     if (e->type == E_PLUS) {
       fprintf (output_stream, "+");
@@ -521,7 +521,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     else if (e->type == E_LSL) {
       fprintf (output_stream, "<<");
     }      
-    _gen_dummy_id (buf, 100, ridx);
+    _gen_dummy_id (buf, char_buf_sz, ridx);
     fprintf (output_stream, " %s", buf);
     break;
 
@@ -623,7 +623,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
 	DUMP_DECL_ASSIGN;
 	fprintf (output_stream, "{");
 	for (listitem_t *li = list_first (resl); li; li = list_next (li)) {
-	  _gen_dummy_id (buf, 100, list_ivalue (li));
+	  _gen_dummy_id (buf, char_buf_sz, list_ivalue (li));
 	  fprintf (output_stream, "%s", buf);
 	  if (list_next (li)) {
 	    fprintf (output_stream, ", ");

--- a/yosys.cc
+++ b/yosys.cc
@@ -66,12 +66,12 @@ static struct cell_info {
 
 static double parse_yosys_info (const char *file, double *area)
 {
-  char buf[10240];
+  char buf[char_buf_sz];
   FILE *fp;
   double ret;
   int i;
 
-  snprintf (buf, 10240, "%s.log", file);
+  snprintf (buf, char_buf_sz, "%s.log", file);
   fp = fopen (buf, "r");
   if (!fp) {
     return -1;
@@ -86,7 +86,7 @@ static double parse_yosys_info (const char *file, double *area)
     *area = 0;
   }
 
-  while (fgets (buf, 10240, fp)) {
+  while (fgets (buf, char_buf_sz, fp)) {
     if (strncmp (buf, "ABC:", 4) == 0) {
       char *tmp = strstr (buf, "Delay =");
       if (tmp) {
@@ -185,7 +185,7 @@ bool yosys_run (act_syn_info *s)
   // yosys gets its script passed via stdin (very short)
   char *libfile = config_get_string("synth.liberty.typical");
 
-  char cmd[10240];
+  char cmd[char_buf_sz];
   
   if (strcmp(libfile,"none") != 0) {
     int constr = 0;
@@ -198,7 +198,7 @@ bool yosys_run (act_syn_info *s)
 
     // start of the script
     pos = 0;
-    snprintf (cmd + pos, 10240 - pos, 
+    snprintf (cmd + pos, char_buf_sz - pos, 
 	      "echo \"read_verilog %s; "
 	      "synth -noabc -top %s; ",
 	      s->v_in, s->toplevel);
@@ -206,23 +206,23 @@ bool yosys_run (act_syn_info *s)
 
     // tech map
     if (constr) {
-      snprintf (cmd + pos, 10240 - pos, "abc -constr %s -liberty %s; ",
+      snprintf (cmd + pos, char_buf_sz - pos, "abc -constr %s -liberty %s; ",
 		sdc_file, libfile);
     }
     else {
-      snprintf (cmd + pos, 10240 - pos, "abc -liberty %s; ", libfile);
+      snprintf (cmd + pos, char_buf_sz - pos, "abc -liberty %s; ", libfile);
     }
     pos += strlen (cmd + pos);
 
     // tie cells
     if (s->use_tie_cells) {
-      snprintf (cmd + pos, 10240 - pos, 
+      snprintf (cmd + pos, char_buf_sz - pos, 
 		"hilomap -hicell TIEHIX1 Y -locell TIELOX1 Y -singleton; ");
       pos += strlen (cmd + pos);
     }
 
     // write results
-    snprintf(cmd + pos, 10240 - pos,
+    snprintf(cmd + pos, char_buf_sz - pos,
 	     "write_verilog -nohex -nodec %s;\" | yosys > %s.log",
 	     s->v_out, s->v_out);
   }
@@ -276,14 +276,14 @@ void yosys_cleanup (act_syn_info *s)
 {
   char *sdc_file;
   int len;
-  char cmd[4096];
+  char cmd[char_buf_sz];
 
   len = strlen (s->v_in);
   MALLOC (sdc_file, char, len+3);
   snprintf (sdc_file, len + 3, "%s", s->v_in);
   snprintf (sdc_file + len - 2, 5, ".sdc");
   
-  snprintf(cmd, 4096, "rm %s && rm %s && rm %s && rm %s.* ",
+  snprintf(cmd, char_buf_sz, "rm %s && rm %s && rm %s && rm %s.* ",
 	   s->v_out, s->v_in, sdc_file, s->v_out);
 
   if (config_get_int("synth.expropt.verbose") == 2) {


### PR DESCRIPTION
long module names can overflow several different 1024-size char buffers, causing errors downstream.
error shows up when synthesizing large Expr's whose unique ID ends up being really long due to nested ternaries. 