### PR TITLE
convert char pointers to std::strings

### DIFF
--- a/example/chpexprexample.cc
+++ b/example/chpexprexample.cc
@@ -77,7 +77,7 @@ void chpexprexample::start_new_set ()
     search_var_in_expr (in_expr_bundle, (Expr *) list_value(li));
   }
   ExprBlockInfo* info;
-  // run the syntesis
+  // run the synthesis
   info = optimiser->run_external_opt(expr_set_name, in_expr_bundle, inexprmap, inwidthmap, out_expr_bundle, outexprmap, outwidthmap);
 
   printf("Generated block %s: Area: %e m2, Power: %e W, delay: %e s, max power: %e, min delay: %e, max delay: %e, static power: %e, dynamic power: %e (if 0 => circuit empty, extraction failed or corner not provided)\n", 

--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -135,7 +135,7 @@ ExprCache::ExprCache(const char *datapath_synthesis_tool,
         idx_file << "# ------------------------------------------------------------------------------------------------------------------------" << std::endl;
         idx_file << "# Expression cache index and metrics file" << std::endl;
         idx_file << "# Metrics except area are in triplets (min,typ,max)" << std::endl;
-        idx_file << "# Format: <unique_id> <dir_name> <delay> <static power> <dynamic power> <total power> <area> <mapper_runtime> <io_runtime>" << std::endl;
+        idx_file << "# Format: <unique_id> <file_name> <delay> <static power> <dynamic power> <total power> <area> <mapper_runtime> <io_runtime>" << std::endl;
         idx_file << "# Type: <string> <int> <double (s)> <double (W)> <double (W)> <double (W)> <double (W)> <mapper_runtime (us)> <io_runtime (us)>" << std::endl;
         idx_file << "# ------------------------------------------------------------------------------------------------------------------------" << std::endl;
         idx_file.close();
@@ -161,16 +161,28 @@ ExprCache::ExprCache(const char *datapath_synthesis_tool,
     read_cache();
 }
 
-std::string ExprCache::_gen_unique_id (Expr *e, list_t *in_expr_list, 
-                        iHashtable *width_map, int outwidth, bool hash)
+std::string ExprCache::_gen_unique_id (Expr *e, iHashtable *expr_map, 
+                        iHashtable *width_map, int outwidth)
 {
     list_t *vars = list_new();
     act_expr_collect_ids (vars, e);
     std::string uniq_id = act_expr_to_string(vars, e);
     std::string io_signature = "";
-    for (listitem_t *li = list_first(in_expr_list); li; li = li->next) {
-        Expr *evar = (Expr *)(list_value(li));
-        auto b = ihash_lookup(width_map, (long)evar);
+
+    std::unordered_map<ActId *, Expr *> id_to_expr = {};
+    ihash_iter_t iter;
+    ihash_bucket_t *ib;
+    ihash_iter_init (expr_map, &iter);
+    while ((ib = ihash_iter_next (expr_map, &iter))) 
+    {
+        Expr *e1 = (Expr *)ib->key;
+        id_to_expr.insert({(ActId *)(e1->u.e.l), e1});
+    }
+
+    for (listitem_t *li = list_first(vars); li; li = li->next) 
+    {
+        auto id = (ActId *)(list_value(li));
+        auto b = ihash_lookup(width_map, (long)(id_to_expr.at(id)));
         Assert (b, "var. width not found");
         int width = b->i;
         // gotta append bitwidth   
@@ -181,12 +193,7 @@ std::string ExprCache::_gen_unique_id (Expr *e, list_t *in_expr_list,
     io_signature.append(std::to_string(outwidth));
 
     uniq_id.append(io_signature);
-    if (!hash) return uniq_id;
-
-    auto hashval = std::hash<std::string>{}(uniq_id);
-    std::string hashed_id = std::to_string(hashval);
-    hashed_id.append(io_signature);
-    return hashed_id;
+    return uniq_id;
 }
 
 ExprBlockInfo *ExprCache::synth_expr (int targetwidth,
@@ -195,7 +202,7 @@ ExprBlockInfo *ExprCache::synth_expr (int targetwidth,
                                       iHashtable *in_expr_map,
                                       iHashtable *in_width_map)
 {
-    std::string uniq_id = _gen_unique_id(expr, in_expr_list, in_width_map, targetwidth, true);
+    std::string uniq_id = _gen_unique_id(expr, in_expr_map, in_width_map, targetwidth);
 
     // already have it
     if (path_map.contains(uniq_id)) {

--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -127,7 +127,7 @@ ExprCache::ExprCache(const char *datapath_synthesis_tool,
 
         int fd = lock_file(index_filename);
 
-        std::ofstream idx_file (index_filename.c_str(), std::ios::app);
+        std::ofstream idx_file (index_filename, std::ios::app);
         if (!idx_file) {
             std::cerr << "Error: could not create/open " << index_filename << std::endl;
             exit(1);

--- a/expr_cache.h
+++ b/expr_cache.h
@@ -68,7 +68,7 @@ private:
     int lock_file (std::string);
     void unlock_file (int);
 
-    std::string _gen_unique_id (Expr *, list_t *, iHashtable *, int, bool);
+    std::string _gen_unique_id (Expr *, iHashtable *, iHashtable *, int);
 
     /*
         define a next() function for the

--- a/expr_cache.h
+++ b/expr_cache.h
@@ -68,7 +68,7 @@ private:
     int lock_file (std::string);
     void unlock_file (int);
 
-    std::string _gen_unique_id (Expr *, list_t *, iHashtable *, int);
+    std::string _gen_unique_id (Expr *, list_t *, iHashtable *, int, bool);
 
     /*
         define a next() function for the

--- a/expr_info.h
+++ b/expr_info.h
@@ -89,9 +89,9 @@ enum expropt_metadata {
 };
 
 struct act_syn_info {
-  const char *v_in;
-  const char *v_out;
-  const char *toplevel;
+  std::string v_in;
+  std::string v_out;
+  std::string toplevel;
   bool use_tie_cells;
   void *space;			// use for whatever you want!
 };

--- a/expropt.h
+++ b/expropt.h
@@ -27,11 +27,15 @@
 #include <unordered_map>
 // #include <act/expr_info.h>
 #include "expr_info.h"
+#include <string.h>
+
+#include <filesystem>
+namespace fs = std::filesystem;
 
 static const int char_buf_sz = 1024*32;
 
 /**
- * ExternalExprOpt is an interface that wrapps the syntesis, optimisation and mapping to cells of a set of act expr.
+ * ExternalExprOpt is an interface that wrapps the synthesis, optimisation and mapping to cells of a set of act expr.
  * it will also give you metadata back if the software supports it. 
  * if you 
  */
@@ -59,7 +63,7 @@ public:
    * @param block_prefix the prefix for the expression block - if
    * integer id mode is used
    */
-  ExternalExprOpt( const char *datapath_syntesis_tool,
+  ExternalExprOpt( std::string datapath_synthesis_tool,
 		   const expr_mapping_target mapping_target,
 		   const bool tie_cells,
 		   const std::string expr_file_path = "",
@@ -69,7 +73,7 @@ public:
                         expr_output_file(expr_file_path),
 			expr_prefix(exprid_prefix),
 			module_prefix(block_prefix),
-			mapper(datapath_syntesis_tool),
+			mapper(datapath_synthesis_tool),
 			use_tie_cells(tie_cells),
                         wire_encoding(mapping_target)
   {
@@ -233,7 +237,7 @@ public:
    * are not used on the outputs, they can be used leafs for the
    * outputs again when using the same char* string name.
    */
-  ExprBlockInfo* run_external_opt (const char* expr_set_name,
+  ExprBlockInfo* run_external_opt (std::string expr_set_name,
 				   list_t *in_expr_list,
 				   iHashtable *in_expr_map,
 				   iHashtable *in_width_map,
@@ -285,7 +289,7 @@ public:
    * to hidden_expr_list) with the name (C string pointer) the result
    * of the expression is assinged to
    */
-  ExprBlockInfo* run_external_opt (const char* expr_set_name,
+  ExprBlockInfo* run_external_opt (std::string expr_set_name,
 				   list_t *in_expr_list,
 				   iHashtable *in_expr_map,
 				   iHashtable *in_width_map,
@@ -328,7 +332,7 @@ protected:
      * @param hidden_name_list optinal - an index alligned list containing char* strings, with the name the result of the expression is assinged to.
      */
     void print_expr_verilog (FILE *output_stream,
-			     const char* expr_set_name,
+			     std::string expr_set_name,
 			     list_t *in_list,
 			     iHashtable *inexprmap,
 			     iHashtable *inwidthmap,
@@ -392,17 +396,17 @@ protected:
     const std::string module_prefix;
 
     /**
-     * the software to be used for syntesis and mapping.
+     * the software to be used for synthesis and mapping.
      */
-    const char *mapper;
+    std::string mapper;
 
     /**
-     * should tie cells be incerted by the syntesis software (true), or should v2act take cae of it (false)
+     * should tie cells be incerted by the synthesis software (true), or should v2act take cae of it (false)
      */
     const bool use_tie_cells;
 
     /**
-     * is it a bundeld data or dualrail pass?
+     * is it a bundled data or dualrail pass?
      */
     const expr_mapping_target wire_encoding;
 
@@ -411,8 +415,10 @@ protected:
      */
     char _dummy_prefix[10];
     int _dummy_idx;
-    void _gen_dummy_id (char *buf, int sz, int idx) {
-      snprintf (buf, sz, "%s%d", _dummy_prefix, idx);
+    std::string _gen_dummy_id (int idx) {
+      std::string ret = _dummy_prefix;
+      ret.append(std::to_string(idx));
+      return ret;
     }
     int _gen_fresh_idx () { return _dummy_idx++; }
 


### PR DESCRIPTION
Switch from passing around char buffers to std strings.
Also a minor fix in io signature suffix appending for unique id for expressions.
Added hashing in an earlier commit but then removed it.