### PR TITLE
save pre-synthesis verilog files in cache

### DIFF
--- a/expr_info.h
+++ b/expr_info.h
@@ -104,6 +104,7 @@ private:
     metric_triplet total_power;	//<  total power (W)
     long long mapper_runtime; //<  logic synthesis tool runtime (us)
     long long interface_runtime; //< interface tools (verilog_printing + v2act) runtime (us)
+    std::string unmapped_file; //< unmapped (pre-synthesis) verilog file
     std::string mapped_file; //< mapped verilog file
     std::string unique_id; //< unique id for the generated expression (cache only)
 
@@ -123,6 +124,7 @@ public:
     long long getRuntime() { return mapper_runtime; }
     long long getIORuntime() { return interface_runtime; }
     std::string getMappedFile() { return mapped_file; }
+    std::string getUnmappedFile() { return unmapped_file; }
     std::string getID() { return unique_id; }
     void setID(std::string s) { unique_id = s; }
 
@@ -139,6 +141,7 @@ public:
         const long long e_runtime,
         const long long e_io_runtime,
         std::string e_mapped_file,
+        std::string e_unmapped_file,
         std::string e_unique_id) :
         delay{e_delay},
         total_power{e_power},
@@ -148,6 +151,7 @@ public:
         mapper_runtime{e_runtime},
         interface_runtime{e_io_runtime},
         mapped_file{e_mapped_file},
+        unmapped_file{e_unmapped_file},
         unique_id{e_unique_id}
     { }
                         

--- a/expropt.cc
+++ b/expropt.cc
@@ -508,12 +508,13 @@ ExprBlockInfo* ExternalExprOpt::run_external_opt (std::string expr_set_name,
   }
   auto stop_mapper = high_resolution_clock::now();
   auto duration = duration_cast<microseconds>(stop_mapper - start_mapper);
-  auto ebi = backend(mapped_file, io_duration, duration);
+  auto ebi = backend(mapped_file, verilog_file, io_duration, duration);
   if (__cleanup) cleanup_tmp_files();
   return ebi;
 }
 
 ExprBlockInfo *ExternalExprOpt::backend(std::string _mapped_file,
+                                        std::string _unmapped_file,
                                 std::chrono::microseconds io_duration,
                                 std::chrono::microseconds duration)
 {
@@ -577,6 +578,7 @@ ExprBlockInfo *ExternalExprOpt::backend(std::string _mapped_file,
               duration.count(),
               io_duration.count(),
               _mapped_file,
+              _unmapped_file,
               ""
               );
 

--- a/expropt.h
+++ b/expropt.h
@@ -310,7 +310,7 @@ protected:
   act_syn_info __syn;
 
   void run_v2act(std::string, bool);
-  ExprBlockInfo *backend(std::string, std::chrono::microseconds, std::chrono::microseconds);
+  ExprBlockInfo *backend(std::string, std::string, std::chrono::microseconds, std::chrono::microseconds);
   
   /**
    * print the verilog module, internal takes the inputs and outputs as lists of expressions (plus the properites name and width as maps). 


### PR DESCRIPTION
While synthesizing expressions to add to the cache, also save the corresponding un-mapped verilog file emitted by expropt into the cache. 
FIle name is of the form <ID>pre.v