### PR TITLE
Cleanup run_external_opt functions

### DIFF
--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -317,9 +317,9 @@ ExprBlockInfo *ExprCache::synth_expr (int targetwidth,
         }
 
         std::chrono::microseconds dummy;
-        expr_output_file = _expr_file_path;
+        set_expr_outfile(_expr_file_path);
         backend(fn, fn_pre, dummy, dummy);
-        expr_output_file = "";
+        set_expr_outfile("");
         unlock_file(fd);
         runtime_accessed_set.insert(uniq_id);
     }

--- a/expr_cache.h
+++ b/expr_cache.h
@@ -54,6 +54,10 @@ public:
     */
     std::string get_cache_loc ();
 
+    void set_expr_outfile(std::string x) {
+        expr_output_file = x;
+    }
+
 private:
 
     void read_cache ();

--- a/expropt.h
+++ b/expropt.h
@@ -182,7 +182,16 @@ public:
 				   list_t *in_expr_list,
 				   iHashtable *in_expr_map,
 				   iHashtable *in_width_map,
-           bool __cleanup = true);
+           bool __cleanup = true)
+  {
+    return run_external_opt(std::to_string(expr_set_number), 
+                            targetwidth,
+                            e,
+                            in_expr_list,
+                            in_expr_map,
+                            in_width_map,
+                            __cleanup);
+  }
 
   /* 
    * Same as above but with string name


### PR DESCRIPTION
Move one fn definition to header file - it is literally just a call to another one.