### PR TITLE
Skip v2act step if no output expr file

### DIFF
--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -288,7 +288,7 @@ ExprBlockInfo *ExprCache::synth_expr (int targetwidth,
         write_cache_index_line (uniq_id);
     }
 
-    if (!(runtime_accessed_set.contains(uniq_id)))
+    if (!(runtime_accessed_set.contains(uniq_id)) && !(_expr_file_path.empty()))
     {
         // for ( auto x : runtime_accessed_set ) {
         // fprintf (stdout, "\nMember: %s\n", x.c_str());


### PR DESCRIPTION
If output expr file is empty, then don't waste time running v2act on cached synthesized verilog files.
Coz this is just a run to get metrics of an expr for optimization :)