### PR TITLE
int(0,0) fix

### DIFF
--- a/expropt.h
+++ b/expropt.h
@@ -426,7 +426,7 @@ protected:
       ret.append(std::to_string(idx));
       return ret;
     }
-    int _gen_fresh_idx () { return ++_dummy_idx; } // 0 reserved for int(0,0)
+    int _gen_fresh_idx () { return _dummy_idx++; }
 
     struct pHashtable *_Hexpr;
     struct pHashtable *_Hwidth;

--- a/expropt.h
+++ b/expropt.h
@@ -426,7 +426,7 @@ protected:
       ret.append(std::to_string(idx));
       return ret;
     }
-    int _gen_fresh_idx () { return _dummy_idx++; }
+    int _gen_fresh_idx () { return ++_dummy_idx; } // 0 reserved for int(0,0)
 
     struct pHashtable *_Hexpr;
     struct pHashtable *_Hwidth;

--- a/verilog.cc
+++ b/verilog.cc
@@ -344,19 +344,26 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
     break;
 
   case E_BUILTIN_INT:
-    lidx = print_expression(output_stream, e->u.e.l, exprmap, &lw);
-    
     if (!e->u.e.r) {
       resw = 1;
     }
     else {
       resw = e->u.e.r->u.ival.v;
     }
-    DUMP_DECL_ASSIGN;
-
-    buf = _gen_dummy_id(lidx);
-    fprintf (output_stream, "%s", buf.c_str()); 
-    
+    if (resw==0) {
+      res = 0;
+      buf = _gen_dummy_id(res);
+      fprintf (output_stream, "\twire %s = 0", buf.c_str());
+      if (width) {							
+        *width = resw;							
+      }
+    }
+    else {
+      lidx = print_expression(output_stream, e->u.e.l, exprmap, &lw);
+      DUMP_DECL_ASSIGN;
+      buf = _gen_dummy_id(lidx);
+      fprintf (output_stream, "%s", buf.c_str()); 
+    }
     break;
 
   case (E_QUERY):
@@ -614,8 +621,10 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
 
 	while (e) {
 	  lidx = print_expression (output_stream, e->u.e.l, exprmap, &lw);
-	  resw += lw;
-	  list_iappend (resl, lidx);
+    if (lw>0) {
+      resw += lw;
+      list_iappend (resl, lidx);
+    }
 	  e = e->u.e.r;
 	}
 	DUMP_DECL_ASSIGN;

--- a/verilog.cc
+++ b/verilog.cc
@@ -313,7 +313,7 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
   do {									\
     res = _gen_fresh_idx ();						\
     buf = _gen_dummy_id(res);					\
-    if (resw == 1) {							\
+    if (resw == 1 || resw==0) {							\
       fprintf (output_stream, "\twire %s;\n", buf.c_str());			\
     }									\
     else {								\
@@ -351,12 +351,8 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
       resw = e->u.e.r->u.ival.v;
     }
     if (resw==0) {
-      res = 0;
-      buf = _gen_dummy_id(res);
-      fprintf (output_stream, "\twire %s = 0", buf.c_str());
-      if (width) {							
-        *width = resw;							
-      }
+      DUMP_DECL_ASSIGN;
+      fprintf (output_stream, "0");
     }
     else {
       lidx = print_expression(output_stream, e->u.e.l, exprmap, &lw);

--- a/verilog.cc
+++ b/verilog.cc
@@ -628,14 +628,19 @@ int ExternalExprOpt::print_expression(FILE *output_stream, Expr *e,
 	  e = e->u.e.r;
 	}
 	DUMP_DECL_ASSIGN;
-	fprintf (output_stream, "{");
-	for (listitem_t *li = list_first (resl); li; li = list_next (li)) {
-    buf = _gen_dummy_id(list_ivalue (li));
-	  fprintf (output_stream, "%s", buf.c_str());
-	  if (list_next (li)) {
-	    fprintf (output_stream, ", ");
-	  }
-	}
+  if (list_isempty(resl)) {
+    fprintf (output_stream, "0");
+  }
+  else {
+    fprintf (output_stream, "{");
+    for (listitem_t *li = list_first (resl); li; li = list_next (li)) {
+      buf = _gen_dummy_id(list_ivalue (li));
+      fprintf (output_stream, "%s", buf.c_str());
+      if (list_next (li)) {
+        fprintf (output_stream, ", ");
+      }
+    }
+  }
 	fprintf (output_stream, "}");
       }
       break;


### PR DESCRIPTION
Add support for int(0,0) - it is treated as the constant zero. 
In concatenations alone, it is skipped since it has zero bitwidth.
int(int(0,0),W) = int(0,W)