### PR TITLE
Correct mutex access to cache

### DIFF
--- a/expr_cache.h
+++ b/expr_cache.h
@@ -61,8 +61,10 @@ public:
 private:
 
     void read_cache ();
+    void read_cache_unlocked ();
     void read_cache_index_line (std::string);
     void write_cache_index_line (std::string);
+    void write_cache_index_line_unlocked (std::string);
     void rename_and_pipe (std::ifstream &, std::ofstream &, 
                             const std::vector<std::string>, 
                             const std::vector<std::string>);
@@ -104,5 +106,7 @@ private:
     // Keep track of which exprs have already been copied over
     // To avoid double-defining the same expr blk
     std::unordered_set<std::string> runtime_accessed_set;
+    
+    std::unordered_set<std::string> dump_at_exit;
 
 };


### PR DESCRIPTION
Added functionality so that multiple processes can access the cache simultaneously.
- Single writer to the cache at all times.
- Single synthesizer at all times - this is needed to ensure consistency.
- Cache update by a process is now done when the ExprCache objects destructs - it writes all the new ones it created after reloading the cache index _again_ as someone else could've destructed and modified the index while it was still alive.
- Picks the next available cache verilog file name correctly.

- Caveat: under the rare situation where there are several processes trying to synthesize the _exact same expression_ (that does not exist in the cache already) at the _exact same time_, there will be multiple verilog files corresponding to the same expr in the cache.
However the index (and the cache as a whole) is still consistent - the cache index will only point to one of these files. The remaining duplicates are just litter and do not affect correctness. 
This can be fixed by clearing and rereading the cache index every time a process wants to synthesize but I'm not doing it for now coz it is expensive.