### PR TITLE
fix power metrics order

### DIFF
--- a/expr_cache.cc
+++ b/expr_cache.cc
@@ -473,9 +473,9 @@ void ExprCache::write_cache_index_line_unlocked (std::string uniq_id)
 
     idx_file << uniq_id << idx_file_delimiter << ep << idx_file_delimiter;
     idx_file << eb.getDelay().min_val << idx_file_delimiter << eb.getDelay().typ_val << idx_file_delimiter << eb.getDelay().max_val << idx_file_delimiter;
+    idx_file << eb.getPower().min_val << idx_file_delimiter << eb.getPower().typ_val << idx_file_delimiter << eb.getPower().max_val << idx_file_delimiter;
     idx_file << eb.getStaticPower().min_val << idx_file_delimiter << eb.getStaticPower().typ_val << idx_file_delimiter << eb.getStaticPower().max_val << idx_file_delimiter;
     idx_file << eb.getDynamicPower().min_val << idx_file_delimiter << eb.getDynamicPower().typ_val << idx_file_delimiter << eb.getDynamicPower().max_val << idx_file_delimiter;
-    idx_file << eb.getPower().min_val << idx_file_delimiter << eb.getPower().typ_val << idx_file_delimiter << eb.getPower().max_val << idx_file_delimiter;
     idx_file << eb.getArea() << idx_file_delimiter;
     idx_file << eb.getRuntime() << idx_file_delimiter;
     idx_file << eb.getIORuntime();


### PR DESCRIPTION
the order in which the metrics were written and read were off relative to each other.
